### PR TITLE
Add `insert` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ Library can be installed via [npm](https://www.npmjs.com/package/typescript-arra
 $ npm install typescript-array-utils
 ```
 
-### Examples 
+### Examples
+
+#### insert
+```typescript
+import {insert} from "typescript-array-utils";
+insert([0, 1, 2, 3, 4], 2, 5);
+ //=> [ 0, 1, 5, 2, 3, 4 ]
+```
 
 #### move
 ```typescript

--- a/index.ts
+++ b/index.ts
@@ -4,3 +4,4 @@ export {replace} from "./src/replace";
 export {without} from "./src/without";
 export {move} from "./src/move";
 export {unique} from "./src/unique";
+export {insert} from "./src/insert";

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/es6-shim": "^0.31.32",
     "@types/tape": "^4.2.28",
     "tape": "^4.6.3",
-    "ts-node": "^2.0.0",
+    "ts-node": "^3.3.0",
     "tslint": "^5.1.0",
     "typescript": "^2.1.5"
   },

--- a/src/insert.test.ts
+++ b/src/insert.test.ts
@@ -1,0 +1,26 @@
+import * as test from "tape";
+import {insert} from "./insert";
+
+test("Test element insertion", (t) => {
+	const expected = [0, 5, 1, 2, 3, 4];
+	const actual = insert([0, 1, 2, 3, 4], 1, 5);
+
+	t.equals(actual.length, expected.length);
+	for (var i = 0; i < actual.length; i++) {
+		t.equals(actual[i], expected[i])
+	}
+
+	t.end();
+});
+
+test("Test element insertion at end of array", (t) => {
+	const expected = [0, 1, 2, 3, 4, 5];
+	const actual = insert([0, 1, 2, 3, 4], 5, 5);
+
+	t.equals(actual.length, expected.length);
+	for (var i = 0; i < actual.length; i++) {
+		t.equals(actual[i], expected[i])
+	}
+
+	t.end();
+});

--- a/src/insert.ts
+++ b/src/insert.ts
@@ -1,0 +1,3 @@
+export function insert<T>(a: T[], index: number, element: T): T[] {
+	return [].concat(a.slice(0, index), element, a.slice(index));
+}


### PR DESCRIPTION
This PR adds an `insert` function to complement the `without` function. It's pretty straightforward - really just a small modification of the `replace` function.